### PR TITLE
fix: avoid onresize height loop [SE-4876]

### DIFF
--- a/src/library-authoring/edit-block/LibraryBlock/wrap.js
+++ b/src/library-authoring/edit-block/LibraryBlock/wrap.js
@@ -373,7 +373,10 @@ export default function wrapBlockHtmlForIFrame(html, resources, lmsBaseUrl) {
       ${legacyIncludes}
       ${cssTags}
     </head>
-    <body>
+    <!-- A Studio-served stylesheet will set the body min-height to 100% (a common strategy to allow for background
+    images to fill the viewport), but this has the undesireable side-effect of causing an infinite loop via the
+    onResize event listeners in certain situations.  Resetting it to the default "auto" skirts the problem. -->
+    <body style="min-height: auto">
       ${html}
       ${jsTags}
       <script>


### PR DESCRIPTION
### Description 

Open edX sets a global `min-height: 100%` for the body element (a common strategy to allow for background images to fill the viewport), but this is undesirable for iframes where the `window.onresize` is used to programmatically adjust the iframe height.  Because `onresize` will fire when the body adjusts itself as per its `min-height: 100%`, in certain situations this will lead to an infinite resizing loop.  This is notably visible when:

* Rendering the video block preview when using Firefox: this causes the iframe   size to jiggle indefinitely.
* Rendering the HTML block preview when there are empty block elements (such as   `<p></p>`) that have a vertical margin set (which happens to be the default for HTML xblocks): this will cause the iframe to increase in  height infinitely.

By adding an inline `min-height: auto` on the wrapping body element, this overrides the Studio-served CSS, and thus fixes the problem.

### Test instructions

1. Deploy frontend-app-library-authoring in the devstack and create a library [as per the README](https://github.com/edx/frontend-app-library-authoring/#devstack-installation).
2. Create a new HTML block and edit its OLX by clicking on the "Source" tab, then include this content:
   ```
   <html>
     <p></p>
   </html>
   ```
3. Click save, then on the "View" tab.  You should **not** see the height of the iframe increase infinitely.