### PR TITLE
Renovate config to automate @edx namespaced minor/patch version upgrades 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   "patch": {
     "automerge": true
   },
-  "rebaseStalePrs": true
+  "rebaseStalePrs": true,
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["@edx"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
### Ticket
[Create common renovate config that automates @edx namespaced minor/patch version upgrades](https://github.com/openedx/frontend-wg/issues/116)

### What has changed
Added Renovate config to update and auto merge `@edx` name spaced minor and patch packages.
As no schedule is provided, it will create and merge renovate PRs at any time