### PR TITLE
fix: use Form.Control to stop "Input" not defined error

### DIFF
--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -353,7 +353,7 @@ const LibraryAuthoringPageHeaderBase = ({ intl, library, ...props }) => {
       <h1 className="page-header-title">
         { inputIsActive
           ? (
-            <Input
+            <Form.Control
               autoFocus
               name="title"
               id="title"
@@ -362,7 +362,7 @@ const LibraryAuthoringPageHeaderBase = ({ intl, library, ...props }) => {
               defaultValue={library.title}
               onBlur={handleSaveTitle}
               onKeyDown={event => {
-                if (event.key === 'Enter') { handleSaveTitle(event) }
+                if (event.key === 'Enter') { handleSaveTitle(event); }
               }}
             />
           )


### PR DESCRIPTION
When rebasing https://github.com/openedx/frontend-app-library-authoring/pull/74, I ran into an issue with the library title edit functionality (I was getting an "Input" not defined error)

I decided to test on latest without my changes, and found the issue exists there too. I'm assuming this happened because https://github.com/openedx/frontend-app-library-authoring/pull/61 had not been tested again since https://github.com/openedx/frontend-app-library-authoring/pull/53 was merged

I've tested this replacement and all seems to work as expected.