### PR TITLE
fix: use `--legacy-peer-deps` in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ precommit:
 	npm audit
 
 requirements:
-	npm install
+	npm install --legacy-peer-deps
 
 i18n.extract:
 	# Pulling display strings from .jsx files into .json files...


### PR DESCRIPTION
running `npm install` without `--legacy-peer-deps` on this repo leads to quite a few errors at the moment. ideally we'll put some time into figuring out all the dependency issues, but for now we'll need this if we want to run `extract_translations`