### PR TITLE
docs: change `tutor dev init` to `tutor dev do init`

### DIFF
--- a/tutor-contrib-library-authoring-mfe/README.rst
+++ b/tutor-contrib-library-authoring-mfe/README.rst
@@ -16,7 +16,7 @@ Then, follow these instructions to enable this microfrontend:
 1. Install this plugin: ``pip install -e 'git+https://github.com/openedx/frontend-app-library-authoring.git#egg=tutor-contrib-library-authoring-mfe&subdirectory=tutor-contrib-library-authoring-mfe'``
 2. Enable the plugin: ``tutor plugins enable library_authoring_mfe``
 3. Run ``tutor config save``.
-4. Run ``tutor dev init -l library_authoring_mfe`` to set the required waffle flags in the CMS.
+4. Run ``tutor dev do init -l library_authoring_mfe`` to set the required waffle flags in the CMS.
 5. Restart your Tutor Nightly Dev environment and also start this with ``tutor dev start library-authoring``
 6. Go to http://studio.local.overhang.io:8001/home/ , click "Libraries", and create a new library with
    "Library Type: Complex (beta)"


### PR DESCRIPTION
per breaking change in v15.0.0: https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1500-2022-12-06

Without this change, the line:
```
tutor dev init -l library_authoring_mfe
```
would fail with:
```
Usage: tutor dev [OPTIONS] COMMAND [ARGS]...
Try 'tutor dev -h' for help.

Error: No such command 'init'.
```