### PR TITLE
fix: in tutor plugin's webpack config, fix `fs` double declaration

### DIFF
--- a/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/plugin.py
+++ b/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/plugin.py
@@ -47,8 +47,6 @@ hooks.Filters.CONFIG_DEFAULTS.add_item(("LIBRARY_AUTHORING_MFE_APP", {
 # development, so we have to restore it here manually.
 # https://github.com/openedx/frontend-app-library-authoring/blob/b95c198b/webpack.dev.config.js
 hooks.Filters.ENV_PATCHES.add_item(("mfe-webpack-dev-config","""
-const fs = require('fs');
-
 // If this is the Library Authoring MFE, apply this fix:
 if (fs.existsSync("src/library-authoring/edit-block/LibraryBlock/xblock-bootstrap.html")) {
     const path = require('path');


### PR DESCRIPTION
The mfe-webpack-dev-config tries to define `const fs`, even though that constant is already defined at the top of the file.

Fixes this error, from `tutor dev dc build`:

    > fedx-scripts webpack-dev-server --progress "--config" "./webpack.dev-tutor.config.js"

    [webpack-cli] Failed to load '/openedx/app/webpack.dev-tutor.config.js' config
    [webpack-cli] /openedx/app/webpack.dev-tutor.config.js:24
    const fs = require('fs');
	  ^

    SyntaxError: Identifier 'fs' has already been declared

@brian-smith-tcril @bradenmacdonald , could one of you review?