### PR TITLE
chore: add CODEOWNERS file to repo, point to tnl

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# The following users are the maintainers of all frontend-app-library-authoring files
+*       @openedx/teaching-and-learning


### PR DESCRIPTION
This is related to Maintainership Pilot expectations.  This CODEOWNERS file will notify teaching-and-learning team members of PR submissions, but there are currently no additional branch protections related to this ownership.