### PR TITLE
chore: add catalog-info file for Open edX Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: 'frontend-app-library-authoring'
-  description: "The frontend (MFE) for openEdx Content Library Authoring"
+  description: "The frontend (MFE) for Open edX Content Library Authoring"
   links:
     - url: "https://github.com/openedx/frontend-app-library-authoring"
       title: "Frontend app library authoring"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'frontend-app-library-authoring'
+  description: "The frontend (MFE) for openEdx Content Library Authoring"
+  links:
+    - url: "https://github.com/openedx/frontend-app-library-authoring"
+      title: "Frontend app library authoring"
+      icon: "Web"
+  annotations:
+    openedx.org/arch-interest-groups: ""
+spec:
+  owner: group:teaching-and-learning
+  type: 'website'
+  lifecycle: 'experimental'


### PR DESCRIPTION
This file populates Backstage info for the Open edX community.  It helps identify that tnl is the owner of this component.  This is in relation to Maintainership OEP-55.