### PR TITLE
feat: use `atlas` in `make pull_translations`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export TRANSIFEX_RESOURCE = frontend-app-library-authoring
 transifex_langs = "ar,fr,es_419,zh_CN"
 
+intl_imports = ./node_modules/.bin/intl-imports.js
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
@@ -45,9 +46,23 @@ push_translations:
 	# Pushing comments to Transifex...
 	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
+ifeq ($(OPENEDX_ATLAS_PULL),)
 # Pulls translations from Transifex.
 pull_translations:
 	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
+else
+# Experimental: OEP-58 Pulls translations using atlas
+pull_translations:
+	rm -rf src/i18n/messages
+	mkdir src/i18n/messages
+	cd src/i18n/messages \
+      && atlas pull --filter=$(transifex_langs) \
+               translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+               translations/paragon/src/i18n/messages:paragon \
+               translations/frontend-app-library-authoring/src/i18n/messages:frontend-app-library-authoring
+
+	$(intl_imports) frontend-component-footer paragon frontend-app-library-authoring
+endif
 
 # This target is used by CI.
 validate-no-uncommitted-package-lock-changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
-        "@edx/frontend-component-footer": "^11.7.2",
-        "@edx/frontend-component-header": "^3.7.2",
-        "@edx/frontend-platform": "^4.1.0",
+        "@edx/frontend-component-footer": "11.7.3",
+        "@edx/frontend-component-header": "3.7.3",
+        "@edx/frontend-platform": "4.2.0",
         "@edx/paragon": "^20.17.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -2242,11 +2242,11 @@
       }
     },
     "node_modules/@edx/frontend-component-footer": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.2.tgz",
-      "integrity": "sha512-joyygHAE8kuG50FIjiY8obEG0ARVAVRrJXOiOCHWGfu2Mie02/Rv0lFpwTdeBC0AHS6rnegXSdzhjuVgigyx1A==",
+      "version": "11.7.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.3.tgz",
+      "integrity": "sha512-CSLofrLoCglJTSk9SxdTAF/5nqjlJDcisgzSFj57+ecMcbqCUyZlE7yFxKly3NGMnNw+lXIYr9hps7gpOQMnHg==",
       "dependencies": {
-        "@edx/frontend-platform": "^4.0.1",
+        "@edx/frontend-platform": "^4.1.0",
         "@fortawesome/fontawesome-svg-core": "6.4.0",
         "@fortawesome/free-brands-svg-icons": "6.4.0",
         "@fortawesome/free-regular-svg-icons": "6.4.0",
@@ -2329,11 +2329,11 @@
       }
     },
     "node_modules/@edx/frontend-component-header": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.2.tgz",
-      "integrity": "sha512-tUGatyYfFB5bKg+iqbFfvRNtvLM54A7WlRKWQ4dY3iIjcMDCD99CcdfqGup3gbIMIBehS14o0skDs2J8R3OElw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.3.tgz",
+      "integrity": "sha512-FbjQ3agHXkZmNzV8cpQg+F3ttvlhqGDnMrxOFuQhb9eFJK48q+L0PhfhCjKx+tPi3aeovtcc0vjG/dzGZs5+Gw==",
       "dependencies": {
-        "@edx/frontend-platform": "^4.0.1",
+        "@edx/frontend-platform": "^4.1.0",
         "@edx/paragon": "20.30.1",
         "@fortawesome/fontawesome-svg-core": "6.3.0",
         "@fortawesome/free-brands-svg-icons": "6.3.0",
@@ -2420,9 +2420,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.1.0.tgz",
-      "integrity": "sha512-7RzN68zaGJS3JZ2UJNx9UTz/qt+TqPAaF9+ngUEhF1iuZCBqoxW2tSg6splHlzXtW9Xk4xBmx5IbssoZWf57iw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.2.0.tgz",
+      "integrity": "sha512-iDoFeccENQKBjqUgdjl5KSwBrjNEj8YW6Ual+6twcHHJUBg3yRoBEphwHIoRREcMgQjhdKVAdWj8eleh4JsEKA==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
-    "@edx/frontend-component-footer": "^11.7.2",
-    "@edx/frontend-component-header": "^3.7.2",
-    "@edx/frontend-platform": "^4.1.0",
+    "@edx/frontend-component-footer": "11.7.3",
+    "@edx/frontend-component-header": "3.7.3",
+    "@edx/frontend-platform": "4.2.0",
     "@edx/paragon": "^20.17.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,3 +1,6 @@
+import { messages as footerMessages } from '@edx/frontend-component-footer';
+import { messages as paragonMessages } from '@edx/paragon';
+
 import arMessages from './messages/ar.json';
 import caMessages from './messages/ca.json';
 // no need to import en messages-- they are in the defaultMessage field
@@ -13,7 +16,7 @@ import ruMessages from './messages/ru.json';
 import thMessages from './messages/th.json';
 import ukMessages from './messages/uk.json';
 
-const messages = {
+const appMessages = {
   ar: arMessages,
   'es-419': es419Messages,
   fr: frMessages,
@@ -29,4 +32,8 @@ const messages = {
   uk: ukMessages,
 };
 
-export default messages;
+export default [
+  footerMessages,
+  paragonMessages,
+  appMessages,
+];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,9 +7,8 @@ import {
   APP_INIT_ERROR, APP_READY, initialize, mergeConfig, subscribe,
 } from '@edx/frontend-platform';
 import { AppProvider, ErrorPage } from '@edx/frontend-platform/react';
-import Footer, { messages as footerMessages } from '@edx/frontend-component-footer';
-import { messages as paragonMessages } from '@edx/paragon';
-import appMessages from './i18n';
+import Footer from '@edx/frontend-component-footer';
+import messages from './i18n';
 import store from './store';
 import { NotFoundPage } from './generic';
 import {
@@ -70,10 +69,6 @@ subscribe(APP_INIT_ERROR, (error) => {
 });
 
 initialize({
-  messages: [
-    appMessages,
-    footerMessages,
-    paragonMessages,
-  ],
+  messages,
   requireAuthenticatedUser: true,
 });


### PR DESCRIPTION
Changes
-------
 - Move all i18n imports into `src/i18n/index.js` so intl-imports.js can override it with latest translations
 - Add `atlas` into `make pull_translations` when `OPENEDX_ATLAS_PULL` environment variable is set.

Testing
-------
 - [x] Fix tests and lint rules
 - [x] Test pulled translations


References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes:

**For Micro-frontends:**

 - Legacy hardcoded translations are kept into the repo.
 - Consolidate all i18n imports into `src/i18n/index.js`
 - Add `atlas` integration in `make pull_translations` but only if `OPENEDX_ATLAS_PULL` is set
 - Bump frontend-platform and use `intl-imports.js` to generate up to date import files
 - If translations is missing, they're added according to the latest Micro-frontend i18n pattern in par with https://github.com/openedx/frontend-template-application/


