### PR TITLE
feat: add webpack.prod.config.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,8 +56,7 @@
         "jest-fetch-mock": "3.0.3",
         "mock-xmlhttprequest": "8.2.0",
         "redux-mock-store": "1.5.4",
-        "rosie": "2.1.0",
-        "webpack-merge": "5.8.0"
+        "rosie": "2.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "jest-fetch-mock": "3.0.3",
     "mock-xmlhttprequest": "8.2.0",
     "redux-mock-store": "1.5.4",
-    "rosie": "2.1.0",
-    "webpack-merge": "5.8.0"
+    "rosie": "2.1.0"
   }
 }

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { createConfig } = require('@edx/frontend-build');
 const CopyPlugin = require('copy-webpack-plugin');
 
-const config = createConfig('webpack-dev');
+const config = createConfig('webpack-prod');
 
 /**
  * Allow serving xblock-bootstrap.html from the MFE itself.


### PR DESCRIPTION
We also need to serve xblock-bootstrap.html from the MFE itself in production, so add the corresponding webpack configuration.

In doing so, also refactor the dev config to match the prod one so we don't have to explicitly devDepend on `webpack-merge` anymore.