### PR TITLE
feat: reload block on editor exit

### DIFF
--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -79,7 +79,7 @@ const getHandlerUrl = async (blockId) => getXBlockHandlerUrl(blockId, XBLOCK_VIE
  */
 export const BlockPreviewBase = ({
   intl, block, view, canEdit, showPreviews, showDeleteModal,
-  setShowDeleteModal, showEditorModal, setShowEditorModal, library, previewKey, editView, isLtiUrlGenerating,
+  setShowDeleteModal, showEditorModal, setShowEditorModal, setUpdatedBlock, library, editView, isLtiUrlGenerating,
   ...props
 }) => (
   <Card className="w-auto m-2">
@@ -115,7 +115,10 @@ export const BlockPreviewBase = ({
         blockId={block.id}
         studioEndpointUrl={getConfig().STUDIO_BASE_URL}
         lmsEndpointUrl={getConfig().LMS_BASE_URL}
-        returnFunction={() => () => setShowEditorModal(false)}
+        returnFunction={() => () => {
+          setShowEditorModal(false);
+          setUpdatedBlock(true);
+        }}
       />
     </ModalDialog>
     <ModalDialog
@@ -144,7 +147,7 @@ export const BlockPreviewBase = ({
     {showPreviews && (
       <Card>
         <Card.Body>
-          <LibraryBlock getHandlerUrl={getHandlerUrl} view={view} key={previewKey} />
+          <LibraryBlock getHandlerUrl={getHandlerUrl} view={view} />
         </Card.Body>
       </Card>
     )}
@@ -164,7 +167,6 @@ BlockPreviewBase.propTypes = {
   showEditorModal: PropTypes.bool.isRequired,
   setShowEditorModal: PropTypes.func.isRequired,
   deleteLibraryBlock: PropTypes.func.isRequired,
-  previewKey: PropTypes.string.isRequired,
   fetchBlockLtiUrl: PropTypes.func.isRequired,
   isLtiUrlGenerating: PropTypes.bool,
 };
@@ -191,6 +193,10 @@ const BlockPreviewContainerBase = ({
   // doing it more than once, or running them when the state can no longer support these actions.
   //
   // This problem feels like there should be some way to generalize it and wrap it to avoid this issue.
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showEditorModal, setShowEditorModal] = useState(false);
+  const [updatedBlock, setUpdatedBlock] = useState(false); 
+  
   useEffect(() => {
     props.initializeBlock({
       blockId: block.id,
@@ -203,22 +209,16 @@ const BlockPreviewContainerBase = ({
     if (needsMeta({ blockStates, id: block.id })) {
       props.fetchLibraryBlockMetadata({ blockId: block.id });
     }
-    if (needsView({ blockStates, id: block.id })) {
+    if (needsView({ blockStates, id: block.id }) || updatedBlock) {
       props.fetchLibraryBlockView({
         blockId: block.id,
         viewSystem: XBLOCK_VIEW_SYSTEM.Studio,
         viewName: 'student_view',
       });
+      setUpdatedBlock(false);
     }
-  }, [blockStates[block.id], showPreviews]);
+  }, [blockStates[block.id], showPreviews, updatedBlock]);
 
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [showEditorModal, setShowEditorModal] = useState(false);
-  // Need to force the iframe to be different if navigating away. Otherwise landing on the edit page
-  // will show the student view, and navigating back will show the edit view in the block list. React is smart enough
-  // to guess these iframes are the same between routes and will try to preserve rather than rerender, but that works
-  // against us here. Setting an explicit key prevents it from matching the two.
-  const previewKey = useMemo(() => `${uuid4()}`, [block.id]);
 
   if (blockStates[block.id] === undefined) {
     return <LoadingPage loadingMessage={intl.formatMessage(messages['library.detail.loading.message'])} />;
@@ -261,9 +261,9 @@ const BlockPreviewContainerBase = ({
       setShowEditorModal={setShowEditorModal}
       deleteLibraryBlock={props.deleteLibraryBlock}
       library={library}
-      previewKey={previewKey}
       isLtiUrlGenerating={isLtiUrlGenerating}
       fetchBlockLtiUrl={props.fetchBlockLtiUrl}
+      setUpdatedBlock={setUpdatedBlock}
     />
   );
 };

--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   ActionRow,
@@ -166,6 +166,7 @@ BlockPreviewBase.propTypes = {
   setShowDeleteModal: PropTypes.func.isRequired,
   showEditorModal: PropTypes.bool.isRequired,
   setShowEditorModal: PropTypes.func.isRequired,
+  setUpdatedBlock: PropTypes.func.isRequired,
   deleteLibraryBlock: PropTypes.func.isRequired,
   fetchBlockLtiUrl: PropTypes.func.isRequired,
   isLtiUrlGenerating: PropTypes.bool,
@@ -195,8 +196,8 @@ const BlockPreviewContainerBase = ({
   // This problem feels like there should be some way to generalize it and wrap it to avoid this issue.
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showEditorModal, setShowEditorModal] = useState(false);
-  const [updatedBlock, setUpdatedBlock] = useState(false); 
-  
+  const [updatedBlock, setUpdatedBlock] = useState(false);
+
   useEffect(() => {
     props.initializeBlock({
       blockId: block.id,
@@ -218,7 +219,6 @@ const BlockPreviewContainerBase = ({
       setUpdatedBlock(false);
     }
   }, [blockStates[block.id], showPreviews, updatedBlock]);
-
 
   if (blockStates[block.id] === undefined) {
     return <LoadingPage loadingMessage={intl.formatMessage(messages['library.detail.loading.message'])} />;

--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -115,9 +115,11 @@ export const BlockPreviewBase = ({
         blockId={block.id}
         studioEndpointUrl={getConfig().STUDIO_BASE_URL}
         lmsEndpointUrl={getConfig().LMS_BASE_URL}
-        returnFunction={() => () => {
+        returnFunction={() => (resp) => {
           setShowEditorModal(false);
-          setUpdatedBlock(true);
+          if (resp) {
+            setUpdatedBlock(true);
+          }
         }}
       />
     </ModalDialog>

--- a/src/library-authoring/edit-block/LibraryBlock/LibraryBlock.jsx
+++ b/src/library-authoring/edit-block/LibraryBlock/LibraryBlock.jsx
@@ -95,10 +95,10 @@ class LibraryBlock extends React.Component {
 
       // Load the XBlock HTML into the IFrame:
       //   iframe will only re-render in react when its property changes (key here)
-      this.setState({ 
+      this.setState(prevState => ({
         html,
-        iframeKey: this.state.iframeKey === 1 ? 0 : 1,
-      });
+        iframeKey: prevState.iframeKey + 1,
+      }));
     }
   }
 

--- a/src/library-authoring/edit-block/LibraryBlock/LibraryBlock.jsx
+++ b/src/library-authoring/edit-block/LibraryBlock/LibraryBlock.jsx
@@ -24,6 +24,7 @@ class LibraryBlock extends React.Component {
     this.state = {
       html: null,
       iFrameHeight: 400,
+      iframeKey: 0,
     };
   }
 
@@ -93,7 +94,11 @@ class LibraryBlock extends React.Component {
       );
 
       // Load the XBlock HTML into the IFrame:
-      this.setState({ html });
+      //   iframe will only re-render in react when its property changes (key here)
+      this.setState({ 
+        html,
+        iframeKey: this.state.iframeKey === 1 ? 0 : 1,
+      });
     }
   }
 
@@ -114,6 +119,7 @@ class LibraryBlock extends React.Component {
       }}
       >
         <iframe
+          key={this.state.iframeKey}
           ref={this.iframeRef}
           title="block"
           src={getConfig().SECURE_ORIGIN_XBLOCK_BOOTSTRAP_HTML_URL}


### PR DESCRIPTION
This PR reloads the block in the library after it exiting its editor. To test, make changes to a block and save it. The changes should appear in the library without needing to refresh the page.

https://2u-internal.atlassian.net/browse/TNL-10926