### PR TITLE
feat: upd frontend platform to 4.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/frontend-component-footer": "12.2.1",
         "@edx/frontend-component-header": "4.6.0",
         "@edx/frontend-lib-content-components": "1.170.2",
-        "@edx/frontend-platform": "4.6.2",
+        "@edx/frontend-platform": "4.6.3",
         "@edx/paragon": "20.46.2",
         "@fortawesome/fontawesome-svg-core": "6.4.2",
         "@fortawesome/free-brands-svg-icons": "6.4.2",
@@ -3522,9 +3522,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.6.2.tgz",
-      "integrity": "sha512-8BugPnykTrUrX2y3GROIGQhH1cWk29eUyi6auJ2NxDgsou9M/YQfVN/LW1oQ4DZ/kjH6KVHKtVva531EDbUNXA==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.6.3.tgz",
+      "integrity": "sha512-vvmg2rWfjdOD9BKcHiFlV3n4kVGqMGUYS0UrIk8Dx7BYbb7It03q/twe5b2D3PHQwvNCTei9EgX8+Tn1QhkXBA==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
         "@formatjs/intl-pluralrules": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@edx/frontend-component-footer": "12.2.1",
     "@edx/frontend-component-header": "4.6.0",
     "@edx/frontend-lib-content-components": "1.170.2",
-    "@edx/frontend-platform": "4.6.2",
+    "@edx/frontend-platform": "4.6.3",
     "@edx/paragon": "20.46.2",
     "@fortawesome/fontawesome-svg-core": "6.4.2",
     "@fortawesome/free-brands-svg-icons": "6.4.2",


### PR DESCRIPTION
`frontend-platform` 4.6.2 broke github lint checks. Hopefully this fixes it.