### PR TITLE
fix: remove other component filter option

### DIFF
--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -340,7 +340,10 @@ const deriveTypeOptions = (blockTypes, intl) => {
   let typeOptions = blockTypes.map((typeSpec) => (
     { value: typeSpec.block_type, label: typeSpec.display_name }
   ));
-  typeOptions.push({ value: '^', label: intl.formatMessage(messages['library.detail.other_component']) });
+
+  /* push is commented out until Advanced blocks are allowed as other filter is not neccesary */
+  // typeOptions.push({ value: '^', label: intl.formatMessage(messages['library.detail.other_component']) });
+
   typeOptions = typeOptions.filter((entry) => BLOCK_FILTER_ORDER.includes(entry.value));
   typeOptions.sort((a, b) => {
     const aOrder = BLOCK_FILTER_ORDER.indexOf(a.value);

--- a/src/library-authoring/author-library/specs/LibraryAuthoringPage.spec.jsx
+++ b/src/library-authoring/author-library/specs/LibraryAuthoringPage.spec.jsx
@@ -291,26 +291,27 @@ testSuite('<LibraryAuthoringPageContainer />', () => {
     }));
   });
 
-  it('Filters blocks by other types', async () => {
-    const library = libraryFactory({
-      blockTypes: [
-        { block_type: 'squirrel', display_name: 'Squirrel' },
-        { block_type: 'fox', display_name: 'Fox' },
-        VIDEO_TYPE,
-      ],
-    });
-    await render(library, genState(library));
-    const filter = screen.getByTestId('filter-dropdown');
-    act(() => {
-      fireEvent.change(filter, { target: { value: '^' } });
-    });
-    await waitFor(() => expect(searchLibrary.fn).toHaveBeenCalledWith({
-      libraryId: library.id,
-      query: '',
-      types: ['squirrel', 'fox'],
-      paginationParams,
-    }));
-  });
+  /* Test is commented out until Advanced blocks are allowed as other filter is not neccesary */
+  // it('Filters blocks by other types', async () => {
+  //   const library = libraryFactory({
+  //     blockTypes: [
+  //       { block_type: 'squirrel', display_name: 'Squirrel' },
+  //       { block_type: 'fox', display_name: 'Fox' },
+  //       VIDEO_TYPE,
+  //     ],
+  //   });
+  //   await render(library, genState(library));
+  //   const filter = screen.getByTestId('filter-dropdown');
+  //   act(() => {
+  //     fireEvent.change(filter, { target: { value: '^' } });
+  //   });
+  //   await waitFor(() => expect(searchLibrary.fn).toHaveBeenCalledWith({
+  //     libraryId: library.id,
+  //     query: '',
+  //     types: ['squirrel', 'fox'],
+  //     paginationParams,
+  //   }));
+  // });
 
   it('Commits changes', async () => {
     const library = libraryFactory({ has_unpublished_changes: true });


### PR DESCRIPTION
JIRA Ticket: [TNL-10999](https://2u-internal.atlassian.net/browse/TNL-10999)

This PR "removes" the other component filter option because the Advanced button that adds other block types is not in the current version of the MFE.