### PR TITLE
fix: iframe styling

### DIFF
--- a/src/library-authoring/author-library/index.scss
+++ b/src/library-authoring/author-library/index.scss
@@ -5,7 +5,7 @@
     }
 
     .pgn__card-header-content {
-        margin-top: 0.6rem;
+        margin-top: 20px !important;
     }
 }
 

--- a/src/library-authoring/edit-block/LibraryBlock/LibraryBlock.jsx
+++ b/src/library-authoring/edit-block/LibraryBlock/LibraryBlock.jsx
@@ -116,7 +116,7 @@ class LibraryBlock extends React.Component {
         position: 'relative',
         overflow: 'hidden',
         minHeight: '200px',
-        margin: '16px',
+        margin: '24px',
       }}
       >
         <iframe

--- a/src/library-authoring/edit-block/LibraryBlock/wrap.js
+++ b/src/library-authoring/edit-block/LibraryBlock/wrap.js
@@ -376,7 +376,7 @@ export default function wrapBlockHtmlForIFrame(html, resources, lmsBaseUrl) {
     <!-- A Studio-served stylesheet will set the body min-height to 100% (a common strategy to allow for background
     images to fill the viewport), but this has the undesireable side-effect of causing an infinite loop via the
     onResize event listeners in certain situations.  Resetting it to the default "auto" skirts the problem. -->
-    <body style="min-height: auto">
+    <body style="min-height: auto; background-color: white">
       ${html}
       ${jsTags}
       <script>


### PR DESCRIPTION
JIRA Tickets: [TNL-11148](https://2u-internal.atlassian.net/browse/TNL-11148), [TNL-11147](https://2u-internal.atlassian.net/browse/TNL-11147)

This PR aligns the component title and action buttons. This PR also fixes the padding around iframe and the iframes background color.

Before
<img width="927" alt="Screenshot 2023-10-30 at 10 03 32 AM" src="https://github.com/openedx/frontend-app-library-authoring/assets/42981026/314e234b-46af-4c3b-9fd3-30e2c9999b6a">

After
<img width="1024" alt="Screenshot 2023-10-30 at 10 02 47 AM" src="https://github.com/openedx/frontend-app-library-authoring/assets/42981026/8e7f47ff-ece9-4b3c-a6ae-82ae0708de8e">
