### PR TITLE
fix: update footer component because it causes edge pipeline fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-        "@edx/frontend-component-footer": "^12.3.0",
+        "@edx/frontend-component-footer": "^12.5.1",
         "@edx/frontend-component-header": "^4.7.0",
         "@edx/frontend-lib-content-components": "^1.175.1",
         "@edx/frontend-platform": "5.6.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-    "@edx/frontend-component-footer": "^12.3.0",
+    "@edx/frontend-component-footer": "^12.5.1",
     "@edx/frontend-component-header": "^4.7.0",
     "@edx/frontend-lib-content-components": "^1.175.1",
     "@edx/frontend-platform": "5.6.1",


### PR DESCRIPTION
Not sure why this only happens in the edge pipeline, but oh well.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @edx/frontend-app-library-authoring@0.1.0
npm ERR! Found: @edx/paragon@21.5.6
npm ERR! node_modules/@edx/paragon
npm ERR!   @edx/paragon@"^21.5.6" from the root project
npm ERR!   peer @edx/paragon@">= 10.0.0 < 22.0.0" from @edx/frontend-platform@5.6.1
npm ERR!   node_modules/@edx/frontend-platform
npm ERR!     @edx/frontend-platform@"5.6.1" from the root project
npm ERR!     peer @edx/frontend-platform@"^4.0.0 || ^5.0.0" from @edx/frontend-component-footer@6.4.0
npm ERR!     node_modules/@edx/frontend-component-footer
npm ERR!       @edx/frontend-component-footer@"npm:@edx/frontend-component-footer-edx@~6.4.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @edx/paragon@"^20.0.0" from @edx/frontend-component-footer@6.4.0
npm ERR! node_modules/@edx/frontend-component-footer
npm ERR!   @edx/frontend-component-footer@"npm:@edx/frontend-component-footer-edx@~6.4.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/go/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/go/.npm/_logs/2023-11-02T19_26_38_663Z-debug-0.log
```