### PR TITLE
[BD-46] feat: added start:with-theme script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "fedx-scripts eslint --ext .js --ext .jsx . --fix",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
+    "start:with-theme": "paragon install-theme && npm start && npm install",
     "test": "fedx-scripts jest --coverage",
     "test:watch": "fedx-scripts jest --coverage --watchAll --watch",
     "clear-jest": "fedx-scripts jest --clearCache"


### PR DESCRIPTION
## Description
Added application start script with the ability to install the required theme (default `@openedx/brand-openedx@latest`). After interrupting a running process, the topic is automatically removed from the `node_modules` directory.

**Related to:** https://github.com/openedx/paragon/issues/2831