### PR TITLE
chore: add atlas for translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@edx/frontend-component-header": "^4.10.1",
         "@edx/frontend-lib-content-components": "^1.175.1",
         "@edx/frontend-platform": "5.6.1",
+        "@edx/openedx-atlas": "^0.6.0",
         "@edx/paragon": "^21.5.6",
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",
@@ -3910,6 +3911,14 @@
       "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
       "dependencies": {
         "@newrelic/publish-sourcemap": "^5.0.1"
+      }
+    },
+    "node_modules/@edx/openedx-atlas": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/openedx-atlas/-/openedx-atlas-0.6.0.tgz",
+      "integrity": "sha512-wZO7hA4VJ/bXjaQNNR7KXGYyTCNs1mBJd3HwQK2EmOwFZYFNX6nzSAm9S7HCfi/kb1PCRpmp3wJt+v/Eu9BEQg==",
+      "bin": {
+        "atlas": "atlas"
       }
     },
     "node_modules/@edx/paragon": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@edx/frontend-component-header": "^4.10.1",
     "@edx/frontend-lib-content-components": "^1.175.1",
     "@edx/frontend-platform": "5.6.1",
+    "@edx/openedx-atlas": "^0.6.0",
     "@edx/paragon": "^21.5.6",
     "@fortawesome/fontawesome-svg-core": "6.5.1",
     "@fortawesome/free-brands-svg-icons": "6.5.1",


### PR DESCRIPTION
many translations in repos will be going away in the next few weeks. if you own an MFE with translations in openedx-translations, please ensure your MFE has the dependency of @edx/openedx-atlas and uses atlas as part of make pull_translations (this has been done for this repo already) [here](https://github.com/openedx/frontend-app-library-authoring/pull/130)